### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .settings
 .settings/*
 
-
+# Annoying macOS
+**/.DS_Store
 
 CM4/Debug/
 CM4/Release/


### PR DESCRIPTION
Gets rid of the @#$% `.DS_Store` files that macOS automatically adds to folders